### PR TITLE
Basic batch publish support

### DIFF
--- a/Service/MessageProducer/ConsoleCommand.php
+++ b/Service/MessageProducer/ConsoleCommand.php
@@ -33,6 +33,18 @@ class ConsoleCommand extends BaseMessageProducer
         $this->doPublish($msg, $routingKey, $extras);
     }
 
+
+    public function batchPublish($messages, $routingKey = null, $ttl = null)
+    {
+        $extras = array();
+        if ($ttl) {
+            $extras = array('expiration' => $ttl * 1000);
+        }
+
+        $this->doBatchPublish($messages, $routingKey, $extras);
+
+    }
+
     protected function getRoutingKey($command, $arguments = array(), $options = array())
     {
         return str_replace(':', '.', $command);


### PR DESCRIPTION
The methods for batch publish was not exposed to client API.

The batchPublish allow to send multiple messages in a single connection, dramatically reducing time spent in HTTP requesting (at least for the SQS driver).
Side note for AWS SQS: Despite the [documentation](http://docs.aws.amazon.com/cli/latest/reference/sqs/send-message-batch.html) saying only 10 messages can be sent at a time, I have been able to send up to 200 messages without any issue.

