### PR TITLE
fix watchdog helper getProcessPid not ignoring grep

### DIFF
--- a/Helper/Watchdog.php
+++ b/Helper/Watchdog.php
@@ -91,7 +91,7 @@ class Watchdog
         } else {
             exec(
             // gotta love escaping single quotes in shell
-                "ps -eo pid,args | fgrep '" . str_replace("'", "'\''", $command) . "' | fgrep -v fgrep",
+                "ps -eo pid,args | fgrep '" . str_replace("'", "'\''", $command) . "' | grep -v grep",
                 $output,
                 $retCode);
 


### PR DESCRIPTION
'fgrep -v fgrep' was not ignoring fgrep as fgrep generates grep -F in the end anyway, so we have to ignore grep and not fgrep.